### PR TITLE
feat: add option to show errors as warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ Currently the plugin has only one configuration setting:
 
 * `failOnWarning`
     * Type: **Boolean**
-    * Default: `false`
+    * Default: `undefined` (falsy)
     * Description: Normally commitlint warnings are considered as valid, but by setting this to true
       the plugin will throw an error if any warnings have been found.
 * `rules`
     * Type: **Object**
     * Default: `{}`
     * Description: Object containing rules as listed at https://github.com/conventional-changelog/commitlint/blob/master/docs/reference-rules.md
+* `warnOnly`
+    * Type: **Boolean**
+    * Default: `undefined` (falsy)
+    * Description: Instead of throwing errors, set maximum level to be warning.
+
+***THREE**, three configuration settings... oh blast it!*
+![](https://static.wikia.nocookie.net/montypython/images/f/ff/Spanish_Inquisition.jpg/revision/latest?cb=20180629171423)
+

--- a/src/analyzeCommits.js
+++ b/src/analyzeCommits.js
@@ -10,7 +10,7 @@ const configuration = {
 async function analyzeCommits(pluginConfig, context) {
     let verified = true;
 
-    const {failOnWarning, rules} = pluginConfig;
+    const {failOnWarning, rules, warnOnly} = pluginConfig;
     const {logger} = context;
 
     // This should never happen! #tinfoilhat
@@ -25,6 +25,11 @@ async function analyzeCommits(pluginConfig, context) {
     }
     const options = await load({ ...configuration, rules });
     let results = [];
+    if (warnOnly) {
+        for (const key in options.rules) {
+            options.rules[key][0] = Math.min(options.rules[key][0], 1);
+        }
+    }
     for (const commit of commits) {
         const result = await lint(
             commit.message,

--- a/src/analyzeCommits.test.js
+++ b/src/analyzeCommits.test.js
@@ -59,6 +59,14 @@ test("Single commit (warning, fail)", async t => {
     }));
 });
 
+
+test("Single commit (errors as warnings)", async t => {
+    await t.notThrowsAsync(analyzeCommits({warnOnly: true}, {
+        ...contextCommons,
+        commits: [invalidCommit]
+    }));
+});
+
 test("Two commits (valid, warning) should not fail", async t => {
     await t.notThrowsAsync(analyzeCommits(doNotFailOnWarningConfig, {
         ...contextCommons,


### PR DESCRIPTION
During transition phases or when trialing the semantic-release and/or conventional commits, it could
be useful to show errors as warnings instead of throw as a way to soft launch the convention.