### PR TITLE
fix(analyzecommits): use @semantic-release/error for errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
+    "@semantic-release/error": "^2.2.0",
     "ava": "^3.15.0",
     "eslint": "^7.24.0",
     "semantic-release": "^17.4.2"

--- a/src/analyzeCommits.js
+++ b/src/analyzeCommits.js
@@ -1,5 +1,6 @@
 const load = require("@commitlint/load").default;
 const lint = require("@commitlint/lint").default;
+const SemanticReleaseError = require("@semantic-release/error");
 
 const formatError = require("./formatError");
 
@@ -43,7 +44,7 @@ async function analyzeCommits(pluginConfig, context) {
     }
     if (!verified) {
         logger.error("semantic-release-commitlint: Commit validation failed!");
-        throw new Error(formatError(results));
+        throw new SemanticReleaseError(formatError(results));
     }
     logger.success("semantic-release-commitlint: Commits validated successfully!");
 }


### PR DESCRIPTION
Using the semantic-release's package for erros instead of the plain Error allows semantic-release to
handle the errors correctly and call appropriate lifecycle methods afterwards.